### PR TITLE
Fix for creating disk images of the correct size

### DIFF
--- a/create-dmg
+++ b/create-dmg
@@ -120,7 +120,7 @@ fi
 # Create the image
 echo "Creating disk image..."
 test -f "${DMG_TEMP_NAME}" && rm -f "${DMG_TEMP_NAME}"
-ACTUAL_SIZE=`du -sm dmg | sed -e 's/    .*//g'`
+ACTUAL_SIZE=`du -sm dmg | sed -e 's/	.*//g'`
 DISK_IMAGE_SIZE=$(expr $ACTUAL_SIZE + 20)
 hdiutil create -srcfolder "$SRC_FOLDER" -volname "${VOLUME_NAME}" -fs HFS+ -fsargs "-c c=64,a=16,e=16" -format UDRW -size ${DISK_IMAGE_SIZE}m "${DMG_TEMP_NAME}"
 


### PR DESCRIPTION
The disk images were create as 300MB which is a major problem if you want to copy 350MB into them...
This patch checks the size of the contents that the image will create and adds 20 MB more to it and uses this value for the image creation step.
