### PR TITLE
Fixed auto-opening dmg file

### DIFF
--- a/create-dmg
+++ b/create-dmg
@@ -173,10 +173,9 @@ chmod -Rf go-w "${MOUNT_DIR}" &> /dev/null || true
 echo "Done fixing permissions."
 
 # make the top window open itself on mount:
-if [ -x /usr/local/bin/openUp ]; then
-    echo "Applying openUp..."
-    /usr/local/bin/openUp "${MOUNT_DIR}"
-fi
+echo "Blessing started"
+bless --folder "${MOUNT_DIR}" --openfolder "${MOUNT_DIR}"
+echo "Blessing finished"
 
 if ! test -z "$VOLUME_ICON_FILE"; then
    # tell the volume that it has a special file attribute


### PR DESCRIPTION
I tried to run this script in Mountain Lion and had a problem: lack of openUp script. I've found it's source in google and compiled it, then executed create-dmg again.

The output was:

Applying openUp...
directory id: 0

And still no auto-open for dmg. Then I migrated to bless instead of openUp and everything worked!
