### PR TITLE
Change sample to show usage of --app-drop-link

### DIFF
--- a/sample
+++ b/sample
@@ -1,3 +1,3 @@
 #! /bin/bash
 test -f test2.dmg && rm test2.dmg
-./create-dmg --window-size 500 300 --background ~/Projects/eclipse-osx-repackager/build/background.gif --icon-size 96 --volname "Hyper Foo" --icon "Applications" 380 205 --icon "Eclipse OS X Repackager" 110 205 test2.dmg /Users/andreyvit/Projects/eclipse-osx-repackager/temp/Eclipse\ OS\ X\ Repackager\ r10/
+./create-dmg --window-size 500 300 --background ~/Projects/eclipse-osx-repackager/build/background.gif --icon-size 96 --volname "Hyper Foo" --app-drop-link 380 205 --icon "Eclipse OS X Repackager" 110 205 test2.dmg /Users/andreyvit/Projects/eclipse-osx-repackager/temp/Eclipse\ OS\ X\ Repackager\ r10/


### PR DESCRIPTION
The sample hadn't been updated along with the script when --app-drop-link was added.
