### PR TITLE
Don't use readlink to get dirname of install dir

### DIFF
--- a/create-dmg
+++ b/create-dmg
@@ -115,7 +115,7 @@ DMG_TEMP_NAME="$DMG_DIR/rw.${DMG_NAME}"
 SRC_FOLDER="$(cd "$2" > /dev/null; pwd)"
 test -z "$VOLUME_NAME" && VOLUME_NAME="$(basename "$DMG_PATH" .dmg)"
 
-AUX_PATH="$(dirname $(readlink $0))/support"
+AUX_PATH="$(dirname $0)/support"
 
 test -d "$AUX_PATH" || {
   echo "Cannot find support directory: $AUX_PATH"


### PR DESCRIPTION
If you use the path to the install directory (which seems the "normal" way of
doing things) then the readlink will return nothing and dirname will fail...

Signed-off-by: Dirk Hohndel dirk@hohndel.org
