### PR TITLE
Cleanup .fseventsd before unmounting

### DIFF
--- a/create-dmg
+++ b/create-dmg
@@ -404,6 +404,10 @@ if [[ -n "$VOLUME_ICON_FILE" ]]; then
 	SetFile -a C "$MOUNT_DIR"
 fi
 
+# Delete unnecessary file system events log
+echo "Deleting .fseventsd"
+rm -rf "${MOUNT_DIR}/.fseventsd"
+
 # Unmount
 echo "Unmounting disk image..."
 hdiutil detach "${DEV_NAME}"


### PR DESCRIPTION
Currently the output DMG contains a .fseventsd directory, which a read-only image doesn't really need. Maybe it would make sense to delete it before unmounting the rw image? (Unless it can break something that I'm not aware of.)