### PR TITLE
Print the path of background image

### DIFF
--- a/create-dmg
+++ b/create-dmg
@@ -322,7 +322,7 @@ DEV_NAME=$(hdiutil attach -readwrite -noverify -noautoopen "${DMG_TEMP_NAME}" | 
 echo "Device name:     $DEV_NAME"
 
 if [[ -n "$BACKGROUND_FILE" ]]; then
-	echo "Copying background file..."
+	echo "Copying background file '$BACKGROUND_FILE'..."
 	[[ -d "$MOUNT_DIR/.background" ]] || mkdir "$MOUNT_DIR/.background"
 	cp "$BACKGROUND_FILE" "$MOUNT_DIR/.background/$BACKGROUND_FILE_NAME"
 fi


### PR DESCRIPTION
I can get the path of volume icon file in the output ([code](https://github.com/create-dmg/create-dmg/blob/121dbfac5ab5c0fde15c895b579130ca7dbfa95e/create-dmg#L343)), so I think we can print the path of background image as well.
