### PR TITLE
[Feature response] Retry the unmounting operation 3 times

### DIFF
--- a/create-dmg
+++ b/create-dmg
@@ -24,6 +24,7 @@ IMAGEKEY=""
 HDIUTIL_VERBOSITY=""
 SANDBOX_SAFE=0
 SKIP_JENKINS=0
+MAXIMUM_UNMOUNTING_ATTEMPTS=3
 
 function pure_version() {
 	echo "$CDMG_VERSION"
@@ -405,8 +406,22 @@ if [[ -n "$VOLUME_ICON_FILE" ]]; then
 fi
 
 # Unmount
-echo "Unmounting disk image..."
-hdiutil detach "${DEV_NAME}"
+unmounting_attempts=0
+until
+  echo "Unmounting disk image..."
+  (( unmounting_attempts++ ))
+  hdiutil detach "${DEV_NAME}"
+	exit_code=$?
+	(( exit_code ==  0 )) && break            # nothing goes wrong
+	(( exit_code != 16 )) && exit $exit_code  # exit with the original exit code
+	# The above statement returns 1 if test failed (exit_code == 16).
+	#   It can make the code in the {do... done} block to be executed
+do
+  (( unmounting_attempts == MAXIMUM_UNMOUNTING_ATTEMPTS )) && exit 16  # patience exhausted, exit with code EBUSY
+	echo "Wait a moment..."
+  sleep $(( 1 * (2 ** unmounting_attempts) ))
+done
+unset unmounting_attempts
 
 # Compress image
 echo "Compressing disk image..."


### PR DESCRIPTION
## Summary

Fixed #115

Related to #114 .

Added 3 attempts with backoff. I borrowed ideas from https://github.com/LinusU/node-appdmg/pull/190 and modified the number of attempts from 5 to 3 per @aonez's suggestion (https://github.com/create-dmg/create-dmg/issues/115#issuecomment-822314128).

## Programming

### set ±e

> I think a temporary `set +e` may be required since you set `set -e` on the top of the script.
> https://github.com/create-dmg/create-dmg/issues/115#issue-860421976

A temporary `set +e` is not required since the exit code of the statement executed in the {until... do} block is used to determine whether the {do... done} block will be executed. In other words, a non-zero exit code in the {until... do} block will not terminate the execution of a script with `set -e` . Therefore, we can safely test the exit code of `hdiutil detach` .

You can search "Exit immediately" in bash's manual page to see the official description.

### how does it work

A small mock script:

```shell
#!/bin/bash


set -e

MAXIMUM_ATTEMPTS=3

attempts=0

until
    date --utc
    (( attempts++ ))
    bash -c "exit $1"
    exit_code=$?
    (( exit_code ==  0 )) && echo 'Nothing goes wrong' && break
    (( exit_code != 16 )) && echo 'Error (not 16)'     && exit $exit_code
do
    (( attempts == MAXIMUM_ATTEMPTS )) && echo 'Error 16' && exit 16
    echo 'wait';
    sleep $(( 1 * (2 ** attempts) ))
done
```

Execute it:

```console
$ bash ./.sh 0
Fri Apr 30 08:19:22 UTC 2021
Nothing goes wrong
$ echo $?
0

$ bash ./.sh 1
Fri Apr 30 08:19:25 UTC 2021
Error (not 16)
$ echo $?
1

$ bash ./.sh 16
Fri Apr 30 08:19:27 UTC 2021
wait
Fri Apr 30 08:19:29 UTC 2021
wait
Fri Apr 30 08:19:33 UTC 2021
Error 16
$ echo $?
16
```

## Test

I tested this on GitHub Actions. In the workflow, I tried to package Firefox like this:

```yml
...
      - uses: actions/checkout@v2
        with:
          ref: 'blahblah'

      - name: Catch the fox
        run: |
          bash ./create-dmg \
            ./dmg.dmg \
            /Applications/Firefox.app
```

And it works!

Log:

```
...
Fri, 30 Apr 2021 05:40:27 GMT | Unmounting disk image...
Fri, 30 Apr 2021 05:40:30 GMT | hdiutil: couldn't eject "disk2" - Resource busy
Fri, 30 Apr 2021 05:40:30 GMT | Wait a moment...
Fri, 30 Apr 2021 05:40:32 GMT | Unmounting disk image...
Fri, 30 Apr 2021 05:40:33 GMT | "disk2" ejected.
Fri, 30 Apr 2021 05:40:33 GMT | Compressing disk image...
...
```

Statistics:

|               | EBUSY | Failed | Retried | Total
|:-             | -:    | -:     | -:      | -:
| Original code | 6     | 6      | /       | 400
| New code      | 3     | 0      | 3       | 400

How to do statistics: By adding [`echo "::warning EBUSY"`](https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-a-warning-message) , I'm able to know how many instances retried the unmounting operation without checking the logs of all instances one by one.

<br>

Please review my code, thank you.
