### PR TITLE
Issue #128 - Add support for ULFO and ULMO formats

### DIFF
--- a/create-dmg
+++ b/create-dmg
@@ -193,6 +193,10 @@ while [[ "${1:0:1}" = "-" ]]; do
 			IMAGEKEY="-imagekey zlib-level=9";;
 		UDBZ)
 			IMAGEKEY="-imagekey bzip2-level=9";;
+		ULFO)
+			;;
+		ULMO)
+			;;
 		*)
 			echo >&2 "Unknown format: $FORMAT"
 			exit 1;;


### PR DESCRIPTION
ULFO - LZFSE/LZVN-compressed, read-only; extension I<.dmg>; create and use on 10.11 ("El Capitan") and later only.
ULMO - LZMA-compressed, read-only; extension I<.dmg>; create and use on 10.15 ("Catalina") and later only.