### PR TITLE
Use "set -o pipefail" and "set -e" to make failed commands in pipelines stop the script

### DIFF
--- a/create-dmg
+++ b/create-dmg
@@ -4,6 +4,8 @@
 
 # Bail out on any unhandled errors
 set -e;
+# Any command that exits with non-zero code will cause the pipeline to fail
+set -o pipefail;
 
 CDMG_VERSION='1.1.0'
 


### PR DESCRIPTION
From https://github.com/create-dmg/create-dmg/issues/137#issuecomment-1186530551 .

There may be an error when executing "```hdiutil ... | foo ...```". If the error comes from "```hdiutil```", the whole pipeline will not fail, and then the script will continue execution. I think this should be fixed.