### PR TITLE
Add support for creating APFS disk images

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ All contents of source\_folder will be copied into the disk image.
 - **--eula \<eula_file\>:** attach a license file to the dmg
 - **--rez \<rez_path\>:** specify custom path to Rez tool used to include license file
 - **--no-internet-enable:** disable automatic mount&copy
-- **--format:** specify the final image format (UDZO|UDBZ|ULFO|ULMO) (default is UDZO) 
+- **--format:** specify the final image format (UDZO|UDBZ|ULFO|ULMO) (default is UDZO)
+- **--filesystem:** specify the image filesystem (HFS+|APFS) (default is HFS+, APFS supports macOS 10.13 or newer)
 - **--add-file \<target_name\> \<file|folder\> \<x\> \<y\>:** add additional file or folder (can be used multiple times)
 - **--disk-image-size \<x\>:** set the disk image size manually to x MB
 - **--hdiutil-verbose:** execute hdiutil in verbose mode
@@ -73,7 +74,7 @@ All contents of source\_folder will be copied into the disk image.
 - **--notarize \<credentials>:** notarize the disk image (waits and staples) with the keychain stored credentials
     For more information check [Apple's documentation](https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution/customizing_the_notarization_workflow)
 - **--skip-jenkins:** skip Finder-prettifying AppleScript, useful in Sandbox and non-GUI environments, [#72](https://github.com/create-dmg/create-dmg/pull/72)
-- **--sandbox-safe:** hdiutil with sandbox compatibility, do not bless and do not execute the cosmetic AppleScript
+- **--sandbox-safe:** hdiutil with sandbox compatibility, do not bless and do not execute the cosmetic AppleScript (not supported for APFS disk images)
 - **--version:** show tool version number
 - **-h, --help:** display the help
 

--- a/create-dmg
+++ b/create-dmg
@@ -18,6 +18,7 @@ WINH=350
 ICON_SIZE=128
 TEXT_SIZE=16
 FORMAT="UDZO"
+FILESYSTEM="HFS+"
 ADD_FILE_SOURCES=()
 ADD_FILE_TARGETS=()
 IMAGEKEY=""
@@ -76,6 +77,8 @@ Options:
       disable automatic mount & copy
   --format <format>
       specify the final disk image format (UDZO|UDBZ|ULFO|ULMO) (default is UDZO)
+  --filesystem <filesystem>
+      specify the disk image filesystem (HFS+|APFS) (default is HFS+, APFS supports macOS 10.13 or newer)
   --add-file <target_name> <file>|<folder> <x> <y>
       add additional file or folder (can be used multiple times)
   --disk-image-size <x>
@@ -91,7 +94,7 @@ Options:
   --notarize <credentials>
       notarize the disk image (waits and staples) with the keychain stored credentials
   --sandbox-safe
-      execute hdiutil with sandbox compatibility and do not bless
+      execute hdiutil with sandbox compatibility and do not bless (not supported for APFS disk images)
   --version
 	    show create-dmg version number
   -h, --help
@@ -162,6 +165,9 @@ while [[ "${1:0:1}" = "-" ]]; do
 		--format)
 			FORMAT="$2"
 			shift; shift;;
+		--filesystem)
+			FILESYSTEM="$2"
+			shift; shift;;
 		--add-file | --add-folder)
 			ADD_FILE_TARGETS+=("$2")
 			ADD_FILE_SOURCES+=("$3")
@@ -230,6 +236,16 @@ if [[ "${DMG_PATH: -4}" != ".dmg" ]]; then
 	exit 1
 fi
 
+if [[ "${FILESYSTEM}" != "HFS+" ]] && [[ "${FILESYSTEM}" != "APFS" ]]; then
+	echo "Unknown disk image filesystem: ${FILESYSTEM}. Run 'create-dmg --help' for help."
+	exit 1
+fi
+
+if [[ "${FILESYSTEM}" == "APFS" ]] && [[ ${SANDBOX_SAFE} -eq 1 ]]; then
+	echo "Creating an APFS disk image that is sandbox safe is not supported."
+	exit 1
+fi
+
 # Main script logic
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
@@ -291,9 +307,14 @@ if [[ -n "$DISK_IMAGE_SIZE" ]]; then
 fi
 
 if [[ $SANDBOX_SAFE -eq 0 ]]; then
+	if [[ "$FILESYSTEM" == "APFS" ]]; then
+		FILESYSTEM_ARGUMENTS=""
+	else
+		FILESYSTEM_ARGUMENTS="-c c=64,a=16,e=16"
+	fi
 	hdiutil create ${HDIUTIL_VERBOSITY} -srcfolder "$SRC_FOLDER" -volname "${VOLUME_NAME}" \
-		-fs HFS+ -fsargs "-c c=64,a=16,e=16" -format UDRW ${CUSTOM_SIZE} "${DMG_TEMP_NAME}"
-else	
+		-fs "${FILESYSTEM}" -fsargs "${FILESYSTEM_ARGUMENTS}" -format UDRW ${CUSTOM_SIZE} "${DMG_TEMP_NAME}"
+else
 	hdiutil makehybrid ${HDIUTIL_VERBOSITY} -default-volume-name "${VOLUME_NAME}" -hfs -o "${DMG_TEMP_NAME}" "$SRC_FOLDER"
 	hdiutil convert -format UDRW -ov -o "${DMG_TEMP_NAME}" "${DMG_TEMP_NAME}"
 	DISK_IMAGE_SIZE_CUSTOM=$DISK_IMAGE_SIZE


### PR DESCRIPTION
APFS disk images support systems running macOS 10.13 and later. I don't know if making "sandbox enabled" disk images using APFS is possible so I disallow this combination of flags.

The use case is not wanting to support older OS systems for app disk images and not wanting to use HFS+, which while testing with create-dmg I've seen have worse performance for extraction*.

(\*tested on macOS 13.0.1 with an app like VLC.app 3.0.18 (arm64; ~134 MB) under heavier compression using ULMO or UDBZ with Finder** and have seen ~2x performance difference; e.g. 3-4 sec vs 6-8 sec)
(**hdiutil is not measured because its disk image mounting implementation is slower as of current writing and doesn't well model a user using the dmg)

 