### PR TITLE
Enable multiple parallel calls

### DIFF
--- a/create-dmg
+++ b/create-dmg
@@ -277,7 +277,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 DMG_DIRNAME="$(dirname "$DMG_PATH")"
 DMG_DIR="$(cd "$DMG_DIRNAME" > /dev/null; pwd)"
 DMG_NAME="$(basename "$DMG_PATH")"
-DMG_TEMP_NAME="$DMG_DIR/rw.${DMG_NAME}"
+DMG_TEMP_NAME="$DMG_DIR/rw.$$.${DMG_NAME}"
 
 # Detect where we're running from
 
@@ -380,20 +380,12 @@ hdiutil resize ${HDIUTIL_VERBOSITY} -size ${DISK_IMAGE_SIZE}m "${DMG_TEMP_NAME}"
 
 # Mount the new DMG
 
-MOUNT_DIR="/Volumes/${VOLUME_NAME}"
-
-# Unmount leftover dmg if it was mounted previously (e.g. developer mounted dmg, installed app and forgot to unmount it)
-if [[ -d "${MOUNT_DIR}" ]]; then
-	echo "Unmounting old disk image from $MOUNT_DIR..."
-	DEV_NAME=$(hdiutil info | grep -E --color=never '^/dev/' | sed 1q | awk '{print $1}')
-	hdiutil_detach_retry "${DEV_NAME}"
-fi
-
 echo "Mounting disk image..."
 
-echo "Mount directory: $MOUNT_DIR"
-DEV_NAME=$(hdiutil attach -readwrite -noverify -noautoopen "${DMG_TEMP_NAME}" | grep -E --color=never '^/dev/' | sed 1q | awk '{print $1}')
+DEV_NAME=$(hdiutil attach -mountrandom /Volumes -readwrite -noverify -noautoopen -nobrowse "${DMG_TEMP_NAME}" | grep -E --color=never '^/dev/' | sed 1q | awk '{print $1}')
 echo "Device name:     $DEV_NAME"
+MOUNT_DIR=$(hdiutil info | grep -E --color=never "${DEV_NAME}s"|head -1|awk '{print $3}')
+echo "Mount dir:       $MOUNT_DIR"
 
 if [[ -n "$BACKGROUND_FILE" ]]; then
 	echo "Copying background file '$BACKGROUND_FILE'..."
@@ -426,6 +418,8 @@ if [[ -n "$ADD_FILE_SOURCES" ]]; then
 		cp -a "${ADD_FILE_SOURCES[$i]}" "$MOUNT_DIR/${ADD_FILE_TARGETS[$i]}"
 	done
 fi
+
+VOLUME_NAME=$(basename $MOUNT_DIR)
 
 # Run AppleScript to do all the Finder cosmetic stuff
 APPLESCRIPT_FILE=$(mktemp -t createdmg.tmp.XXXXXXXXXX)

--- a/create-dmg
+++ b/create-dmg
@@ -129,6 +129,25 @@ EOHELP
 	exit 0
 }
 
+# factors can cause interstitial disk images to contain more than a single
+# partition - expand the hunt for the temporary disk image by checking for
+# the path of the volume, versus assuming its the first result (as in pr/152).
+function find_mount_dir() {
+	local dev_name="${1}"
+
+	>&2 echo "Searching for mounted interstitial disk image using ${dev_name}... "
+	# enumerate up to 9 partitions
+	for i in {1..9}; do
+		# attempt to find the partition
+		local found_dir
+		found_dir=$(hdiutil info | grep -E --color=never "${dev_name}" | head -${i} | awk '{print $3}')
+		if [[ -n "${found_dir}" ]]; then
+				echo "${found_dir}"
+				return 0
+		fi
+	done
+}
+
 # Argument parsing
 
 while [[ "${1:0:1}" = "-" ]]; do
@@ -384,7 +403,14 @@ echo "Mounting disk image..."
 
 DEV_NAME=$(hdiutil attach -mountrandom /Volumes -readwrite -noverify -noautoopen -nobrowse "${DMG_TEMP_NAME}" | grep -E --color=never '^/dev/' | sed 1q | awk '{print $1}')
 echo "Device name:     $DEV_NAME"
-MOUNT_DIR=$(hdiutil info | grep -E --color=never "${DEV_NAME}s"|head -1|awk '{print $3}')
+MOUNT_DIR=$(find_mount_dir "${DEV_NAME}s")
+
+if [[ -z "${MOUNT_DIR}" ]]; then
+  >&2 echo "ERROR: unable to proceed with final disk image creation because the interstitial disk image was not found."
+  >&2 echo "The interstitial disk image will likely be mounted and will need to be cleaned up manually."
+  exit 1
+fi
+
 echo "Mount dir:       $MOUNT_DIR"
 
 if [[ -n "$BACKGROUND_FILE" ]]; then


### PR DESCRIPTION
In a CI/CD environment, it is possible that multiple jobs are running in parallel. In such case, the script will fail because the dmg file is already created by another job.

This commit adds a the PID of the process creating the dmg file to the name of the temporary dmg file. It also uses -mountrandom to mount the dmg file in a random directory. This way, multiple jobs can run in parallel.