### PR TITLE
Add encryption support built into hdiutil when creating disk images

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ All contents of source\_folder will be copied into the disk image.
 - **--no-internet-enable:** disable automatic mount&copy
 - **--format:** specify the final image format (UDZO|UDBZ|ULFO|ULMO) (default is UDZO)
 - **--filesystem:** specify the image filesystem (HFS+|APFS) (default is HFS+, APFS supports macOS 10.13 or newer)
+- **--encrypt:** enable encryption for the resulting disk image (AES-256 - you will be prompted for password)
+- **--encrypt-aes128:** enable encryption for the resulting disk image (AES-128 - you will be prompted for password)
 - **--add-file \<target_name\> \<file|folder\> \<x\> \<y\>:** add additional file or folder (can be used multiple times)
 - **--disk-image-size \<x\>:** set the disk image size manually to x MB
 - **--hdiutil-verbose:** execute hdiutil in verbose mode
@@ -77,6 +79,10 @@ All contents of source\_folder will be copied into the disk image.
 - **--sandbox-safe:** hdiutil with sandbox compatibility, do not bless and do not execute the cosmetic AppleScript (not supported for APFS disk images)
 - **--version:** show tool version number
 - **-h, --help:** display the help
+
+Encryption
+-------
+hdiutil supports native disk image encryption using AES-256 (slower but stronger) or AES-128 (faster but weaker).  Enabling disk image encryption via create-dmg will require the entry of the password during the middle (compression phase) of the process.  Take care to enter the password correctly, because hdiutil will not prompt a second time to confirm the password.
 
 Example
 -------
@@ -111,7 +117,7 @@ We'd like to keep it working in as many versions as possible, but unfortunately,
 
 But if you find a bug in an older version, go ahead and report it! We'll try to work with you to get it fixed.
 
-If you're running OS X 10.5 or later, you're SOL. That's just too hard to deal with in 2020. ;)
+If you're running OS X 10.5 or later, you're SOL. That's just too hard to deal with in 2023. ;)
 
 Alternatives
 ------------

--- a/create-dmg
+++ b/create-dmg
@@ -104,6 +104,10 @@ Options:
       specify the final disk image format (UDZO|UDBZ|ULFO|ULMO) (default is UDZO)
   --filesystem <filesystem>
       specify the disk image filesystem (HFS+|APFS) (default is HFS+, APFS supports macOS 10.13 or newer)
+  --encrypt
+      enable encryption for the resulting disk image (AES-256 - you will be prompted for password)
+  --encrypt-aes128
+      enable encryption for the resulting disk image (AES-128 - you will be prompted for password)
   --add-file <target_name> <file>|<folder> <x> <y>
       add additional file or folder (can be used multiple times)
   --disk-image-size <x>
@@ -193,6 +197,14 @@ while [[ "${1:0:1}" = "-" ]]; do
 		--filesystem)
 			FILESYSTEM="$2"
 			shift; shift;;
+		--encrypt)
+			ENABLE_ENCRYPTION=1
+			AESBITS=256
+			shift;;
+		--encrypt-aes128)
+			ENABLE_ENCRYPTION=1
+			AESBITS=128
+			shift;;
 		--add-file | --add-folder)
 			ADD_FILE_TARGETS+=("$2")
 			ADD_FILE_SOURCES+=("$3")
@@ -488,9 +500,15 @@ rm -rf "${MOUNT_DIR}/.fseventsd" || true
 
 hdiutil_detach_retry "${DEV_NAME}"
 
-# Compress image
-echo "Compressing disk image..."
-hdiutil convert ${HDIUTIL_VERBOSITY} "${DMG_TEMP_NAME}" -format ${FORMAT} ${IMAGEKEY} -o "${DMG_DIR}/${DMG_NAME}"
+# Compress image and optionally encrypt
+if [[ $ENABLE_ENCRYPTION -eq 0 ]]; then
+	echo "Compressing disk image..."
+	hdiutil convert ${HDIUTIL_VERBOSITY} "${DMG_TEMP_NAME}" -format ${FORMAT} ${IMAGEKEY} -o "${DMG_DIR}/${DMG_NAME}"
+else
+	echo "Compressing and encrypting disk image..."
+	echo "NOTE: hdiutil will only prompt a single time for a password - ensure entry is correct."
+	hdiutil convert ${HDIUTIL_VERBOSITY} "${DMG_TEMP_NAME}" -format ${FORMAT} ${IMAGEKEY} -encryption AES-${AESBITS} -stdinpass -o "${DMG_DIR}/${DMG_NAME}"
+fi
 rm -f "${DMG_TEMP_NAME}"
 
 # Adding EULA resources


### PR DESCRIPTION
hdiutil already supports encrypting disk images - this patch takes advantage of the conversion process to apply compression to also allow for encrypting the final disk image.