### PR TITLE
Change wording in a license agreement window

### DIFF
--- a/support/eula-resources-template.xml
+++ b/support/eula-resources-template.xml
@@ -28,7 +28,7 @@
 			YXZlLi4ueklmIHlvdSBhZ3JlZSB3aXRoIHRoZSB0ZXJtcyBvZiB0
 			aGlzIGxpY2Vuc2UsIGNsaWNrICJBZ3JlZSIgdG8gYWNjZXNzIHRo
 			ZSBzb2Z0d2FyZS4gSWYgeW91IGRvIG5vdCBhZ3JlZSwgY2xpY2sg
-			IkRpc2FncmVlLiI=
+			IkRpc2FncmVlIi4=
 			</data>
 			<key>ID</key>
 			<string>5000</string>

--- a/support/eula-resources-template.xml
+++ b/support/eula-resources-template.xml
@@ -27,8 +27,8 @@
 			AAYNRW5nbGlzaCB0ZXN0MQVBZ3JlZQhEaXNhZ3JlZQVQcmludAdT
 			YXZlLi4ueklmIHlvdSBhZ3JlZSB3aXRoIHRoZSB0ZXJtcyBvZiB0
 			aGlzIGxpY2Vuc2UsIGNsaWNrICJBZ3JlZSIgdG8gYWNjZXNzIHRo
-			ZSBzb2Z0d2FyZS4gIElmIHlvdSBkbyBub3QgYWdyZWUsIHByZXNz
-			ICJEaXNhZ3JlZS4i
+			ZSBzb2Z0d2FyZS4gSWYgeW91IGRvIG5vdCBhZ3JlZSwgY2xpY2sg
+			IkRpc2FncmVlLiI=
 			</data>
 			<key>ID</key>
 			<string>5000</string>
@@ -43,8 +43,8 @@
 			AAYHRW5nbGlzaAVBZ3JlZQhEaXNhZ3JlZQVQcmludAdTYXZlLi4u
 			e0lmIHlvdSBhZ3JlZSB3aXRoIHRoZSB0ZXJtcyBvZiB0aGlzIGxp
 			Y2Vuc2UsIHByZXNzICJBZ3JlZSIgdG8gaW5zdGFsbCB0aGUgc29m
-			dHdhcmUuICBJZiB5b3UgZG8gbm90IGFncmVlLCBwcmVzcyAiRGlz
-			YWdyZWUiLg==
+			dHdhcmUuIElmIHlvdSBkbyBub3QgYWdyZWUsIGNsaWNrICJEaXNh
+			Z3JlZSIu
 			</data>
 			<key>ID</key>
 			<string>5002</string>


### PR DESCRIPTION
A client brought my attention to inconsistent wording in the sidebar and this pull request changes the wording to be consistent.

Current wording:
<img width="186" alt="Screenshot 2023-11-23 at 13 58 54" src="https://github.com/create-dmg/create-dmg/assets/415535/66c0f974-27e5-4ef0-ab5d-5180ebfbec51">

(removed additional space before `If you do not agree` and renamed `press "Disagree"` to `click "Disagree"` to be consistent with the previous wording.