### PR TITLE
Remove "--custom-icon" from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ All contents of source\_folder will be copied into the disk image.
 - **--icon-size \<icon_size\>:** set window icons size (up to 128)
 - **--icon \<file_name\> \<x\> \<y\>:** set position of the file's icon
 - **--hide-extension \<file_name\>:** hide the extension of file
-- **--custom-icon \<file_name|custom_icon|sample_file\> \<x\> \<y\>:** set position and -tom icon
 - **--app-drop-link \<x\> \<y\>:** make a drop link to Applications, at location x, y
 - **--ql-drop-link \<x\> \<y\>:** make a drop link to /Library/QuickLook, at location x, y
 - **--eula \<eula_file\>:** attach a license file to the dmg


### PR DESCRIPTION
The argument processing code and the help message have been removed by fbe0f36c823adbcbdcc15f9d65c6354252ac8307 .

I don't know what is a "custom icon" and don't know why the "--custom-icon" option has been removed. Is there an alternative solution?

Answering to #167 would be better.