### PR TITLE
FIx bug when MOUNTDIR has heading '\n'

### DIFF
--- a/create-dmg
+++ b/create-dmg
@@ -144,9 +144,9 @@ function find_mount_dir() {
 	for i in {1..9}; do
 		# attempt to find the partition
 		local found_dir
-		found_dir=$(hdiutil info | grep -E --color=never "${dev_name}" | head -${i} | awk '{print $3}')
+		found_dir=$(hdiutil info | grep -E --color=never "${dev_name}" | head -${i} | awk '{print $3}' | xargs)
 		if [[ -n "${found_dir}" ]]; then
-				echo "$(echo $found_dir | xargs)"
+				echo "${found_dir}"
 				return 0
 		fi
 	done

--- a/create-dmg
+++ b/create-dmg
@@ -146,7 +146,7 @@ function find_mount_dir() {
 		local found_dir
 		found_dir=$(hdiutil info | grep -E --color=never "${dev_name}" | head -${i} | awk '{print $3}')
 		if [[ -n "${found_dir}" ]]; then
-				echo "${found_dir}"
+				echo "$(echo $found_dir | xargs)"
 				return 0
 		fi
 	done


### PR DESCRIPTION
Fix the bug described in https://github.com/create-dmg/create-dmg/issues/169