### PR TITLE
Print message to explain missing background with `--skip-jenkins`

### DIFF
--- a/create-dmg
+++ b/create-dmg
@@ -489,7 +489,7 @@ else
 			| perl -pe "s/APPLICATION_CLAUSE/$APPLICATION_CLAUSE/g" \
 			| perl -pe "s/HIDING_CLAUSE/$HIDING_CLAUSE/" \
 			> "$APPLESCRIPT_FILE"
-		sleep 2 # pause to workaround occasional "Can’t get disk" (-1728) issues  
+		sleep 2 # pause to workaround occasional "Can’t get disk" (-1728) issues
 		echo "Running AppleScript to make Finder stuff pretty: /usr/bin/osascript \"${APPLESCRIPT_FILE}\" \"${VOLUME_NAME}\""
 		if /usr/bin/osascript "${APPLESCRIPT_FILE}" "${VOLUME_NAME}"; then
 			# Okay, we're cool
@@ -567,7 +567,7 @@ if [[ -n "${EULA_RSRC}" && "${EULA_RSRC}" != "-null-" ]]; then
 	# EULA_DATA="$(base64 -b 52 "${EULA_RSRC}" | sed s$'/^\(.*\)$/\t\t\t\\1/')"
 	EULA_DATA="$(openssl base64 -in "${EULA_RSRC}" | tr -d '\n' | awk '{gsub(/.{52}/,"&\n")}1' | sed s$'/^\(.*\)$/\t\t\t\\1/')"
 	# Fill the template with the custom EULA contents
-	eval "cat > \"${EULA_RESOURCES_FILE}\" <<EOF                                                                                                                  
+	eval "cat > \"${EULA_RESOURCES_FILE}\" <<EOF
 	$(<${CDMG_SUPPORT_DIR}/eula-resources-template.xml)
 	EOF
 	"
@@ -593,7 +593,7 @@ else
 fi
 
 if [[ -n "${SIGNATURE}" && "${SIGNATURE}" != "-null-" ]]; then
-	echo "Codesign started"	
+	echo "Codesign started"
 	codesign -s "${SIGNATURE}" "${DMG_DIR}/${DMG_NAME}"
 	dmgsignaturecheck="$(codesign --verify --deep --verbose=2 --strict "${DMG_DIR}/${DMG_NAME}" 2>&1 >/dev/null)"
 	if [ $? -eq 0 ]; then
@@ -605,7 +605,7 @@ if [[ -n "${SIGNATURE}" && "${SIGNATURE}" != "-null-" ]]; then
 fi
 
 if [[ -n "${NOTARIZE}" && "${NOTARIZE}" != "-null-" ]]; then
-	echo "Notarization started"	
+	echo "Notarization started"
 	xcrun notarytool submit "${DMG_DIR}/${DMG_NAME}" --keychain-profile "${NOTARIZE}" --wait
 	echo "Stapling the notarization ticket"
 	staple="$(xcrun stapler staple "${DMG_DIR}/${DMG_NAME}")"

--- a/create-dmg
+++ b/create-dmg
@@ -508,7 +508,9 @@ else
 		sleep 4
 		rm "$APPLESCRIPT_FILE"
 	else
-		echo "Will skip running AppleScript to configure DMG aesthetics because of --skip-jenkins option..."
+		echo "Will skip running AppleScript to configure DMG aesthetics because of --skip-jenkins option."
+		echo "This will result in a DMG without any custom background or icons positioning."
+		echo "More info at https://github.com/create-dmg/create-dmg/issues/72"
 	fi
 fi
 

--- a/create-dmg
+++ b/create-dmg
@@ -502,6 +502,8 @@ else
 		echo "Done running the AppleScript..."
 		sleep 4
 		rm "$APPLESCRIPT_FILE"
+	else
+		echo "Will skip running AppleScript to configure DMG aesthetics because of --skip-jenkins option..."
 	fi
 fi
 

--- a/create-dmg
+++ b/create-dmg
@@ -508,9 +508,11 @@ else
 		sleep 4
 		rm "$APPLESCRIPT_FILE"
 	else
+		echo ''
 		echo "Will skip running AppleScript to configure DMG aesthetics because of --skip-jenkins option."
 		echo "This will result in a DMG without any custom background or icons positioning."
 		echo "More info at https://github.com/create-dmg/create-dmg/issues/72"
+		echo ''
 	fi
 fi
 

--- a/create-dmg
+++ b/create-dmg
@@ -489,7 +489,12 @@ else
 			| perl -pe "s/APPLICATION_CLAUSE/$APPLICATION_CLAUSE/g" \
 			| perl -pe "s/HIDING_CLAUSE/$HIDING_CLAUSE/" \
 			> "$APPLESCRIPT_FILE"
-		sleep 2 # pause to workaround occasional "Can’t get disk" (-1728) issues
+
+		# pause to workaround occasional "Can’t get disk" (-1728) issues
+		ERROR_1728_WORKAROUND_SLEEP_INTERVAL=2
+		echo "Will sleep for $ERROR_1728_WORKAROUND_SLEEP_INTERVAL seconds to workaround occasions \"Can't get disk (-1728)\" issues..."
+		sleep $ERROR_1728_WORKAROUND_SLEEP_INTERVAL
+
 		echo "Running AppleScript to make Finder stuff pretty: /usr/bin/osascript \"${APPLESCRIPT_FILE}\" \"${VOLUME_NAME}\""
 		if /usr/bin/osascript "${APPLESCRIPT_FILE}" "${VOLUME_NAME}"; then
 			# Okay, we're cool


### PR DESCRIPTION
I spent some time scratching my beard to figure out why there was no background in [the DMGs we generate for WordPress Studio](https://github.com/Automattic/studio/pull/135).

I then realized the lack of background was expected given we run with `--skip-jenkins`.

Assuming my understanding of the code and is correct, this PR adds a messages to the script output to clarify the behavior is expected.

<img width="1325" alt="image" src="https://github.com/create-dmg/create-dmg/assets/1218433/14886c70-b1b4-4c5d-95b7-6e6c16d43a9e">

Also adds a message before the 2 seconds sleep, just the script execution doesn't look unresponsive.

<img width="1333" alt="image" src="https://github.com/create-dmg/create-dmg/assets/1218433/ac89f112-1a42-4efb-be60-382214ede2e3">

