### PR TITLE
Added option to leave rw image and overwrite existing dmg file

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ All contents of source\_folder will be copied into the disk image.
 - **--skip-jenkins:** skip Finder-prettifying AppleScript, useful in Sandbox and non-GUI environments, [#72](https://github.com/create-dmg/create-dmg/pull/72)
 - **--applescript-sleep-duration \<x\>:** specify the sleep duration before executing AppleScript to workaround occasional "Can’t get disk" (-1728) issues (default is 5)
 - **--sandbox-safe:** hdiutil with sandbox compatibility, do not bless and do not execute the cosmetic AppleScript (not supported for APFS disk images)
+- **--skip-finalize:** skip creating the final read-only dmg, and leave a writable one
+- **--overwrite:** overwrite the output file if it already exists
 - **--version:** show tool version number
 - **-h, --help:** display the help
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ All contents of source\_folder will be copied into the disk image.
 - **--skip-jenkins:** skip Finder-prettifying AppleScript, useful in Sandbox and non-GUI environments, [#72](https://github.com/create-dmg/create-dmg/pull/72)
 - **--applescript-sleep-duration \<x\>:** specify the sleep duration before executing AppleScript to workaround occasional "Can’t get disk" (-1728) issues (default is 5)
 - **--sandbox-safe:** hdiutil with sandbox compatibility, do not bless and do not execute the cosmetic AppleScript (not supported for APFS disk images)
-- **--skip-finalize:** skip creating the final read-only dmg, and leave a writable one
+- **--skip-finalize:** skip creating the final read-only disk image, and leave a writable one
 - **--overwrite:** overwrite the output file if it already exists
 - **--version:** show tool version number
 - **-h, --help:** display the help

--- a/create-dmg
+++ b/create-dmg
@@ -30,7 +30,9 @@ IMAGEKEY=""
 HDIUTIL_VERBOSITY=""
 SANDBOX_SAFE=0
 BLESS=0
+OVERWRITE=0
 SKIP_JENKINS=0
+SKIP_FINALIZE=0
 MAXIMUM_UNMOUNTING_ATTEMPTS=3
 SIGNATURE=""
 NOTARIZE=""
@@ -126,6 +128,10 @@ Options:
       execute hdiutil with sandbox compatibility and do not bless (not supported for APFS disk images)
   --skip-jenkins
       skip Finder-prettifying AppleScript, useful in Sandbox and non-GUI environments
+  --skip-finalize
+      skip creating the file read-only image, and leave a writeable dmg
+  --overwrite
+	  overwrite the output file if it already exists
   --version
 	    show create-dmg version number
   -h, --help
@@ -260,6 +266,12 @@ while [[ "${1:0:1}" = "-" ]]; do
 		--skip-jenkins)
 			SKIP_JENKINS=1
 			shift;;
+		--skip-finalize)
+			SKIP_FINALIZE=1
+			shift;;
+		--overwrite)
+			OVERWRITE=1
+			shift;;
 		-*)
 			echo "Unknown option: $1. Run 'create-dmg --help' for help."
 			exit 1;;
@@ -291,6 +303,11 @@ SRC_FOLDER="$(cd "$2" > /dev/null; pwd)"
 
 if [[ "${DMG_PATH: -4}" != ".dmg" ]]; then
 	echo "Output file name must end with a .dmg extension. Run 'create-dmg --help' for help."
+	exit 1
+fi
+
+if [[ -f "${DMG_PATH}" ]] && [[ $OVERWRITE -eq 0 ]]; then
+	echo "Output file already exists. Delete file or use the --overwrite option."
 	exit 1
 fi
 
@@ -545,16 +562,28 @@ rm -rf "${MOUNT_DIR}/.fseventsd" || true
 
 hdiutil_detach_retry "${DEV_NAME}"
 
-# Compress image and optionally encrypt
-if [[ $ENABLE_ENCRYPTION -eq 0 ]]; then
-	echo "Compressing disk image..."
-	hdiutil convert ${HDIUTIL_VERBOSITY} "${DMG_TEMP_NAME}" -format ${FORMAT} ${IMAGEKEY} -o "${DMG_DIR}/${DMG_NAME}"
-else
-	echo "Compressing and encrypting disk image..."
-	echo "NOTE: hdiutil will only prompt a single time for a password - ensure entry is correct."
-	hdiutil convert ${HDIUTIL_VERBOSITY} "${DMG_TEMP_NAME}" -format ${FORMAT} ${IMAGEKEY} -encryption AES-${AESBITS} -stdinpass -o "${DMG_DIR}/${DMG_NAME}"
+# Remove target if requested
+if [[ $OVERWRITE -eq 1 ]] && [[ -f "${DMG_DIR}/${DMG_NAME}" ]]; then
+	rm -f "${DMG_DIR}/${DMG_NAME}"
 fi
-rm -f "${DMG_TEMP_NAME}"
+
+# Return intermediate image if requested
+if [[ $SKIP_FINALIZE -eq 1 ]]; then
+	mv "${DMG_TEMP_NAME}" "${DMG_DIR}/${DMG_NAME}"
+	echo "Read-write disk image created"
+	exit 0
+else
+	# Compress image and optionally encrypt
+	if [[ $ENABLE_ENCRYPTION -eq 0 ]]; then
+		echo "Compressing disk image..."
+		hdiutil convert ${HDIUTIL_VERBOSITY} "${DMG_TEMP_NAME}" -format ${FORMAT} ${IMAGEKEY} -o "${DMG_DIR}/${DMG_NAME}"
+	else
+		echo "Compressing and encrypting disk image..."
+		echo "NOTE: hdiutil will only prompt a single time for a password - ensure entry is correct."
+		hdiutil convert ${HDIUTIL_VERBOSITY} "${DMG_TEMP_NAME}" -format ${FORMAT} ${IMAGEKEY} -encryption AES-${AESBITS} -stdinpass -o "${DMG_DIR}/${DMG_NAME}"
+	fi
+	rm -f "${DMG_TEMP_NAME}"
+fi
 
 # Adding EULA resources
 if [[ -n "${EULA_RSRC}" && "${EULA_RSRC}" != "-null-" ]]; then

--- a/create-dmg
+++ b/create-dmg
@@ -345,9 +345,14 @@ if [[ "${DMG_PATH: -4}" != ".dmg" ]]; then
 	exit 1
 fi
 
-if [[ -f "${DMG_PATH}" ]] && [[ $OVERWRITE -eq 0 ]]; then
-	echo "Output file already exists. Delete file or use the --overwrite option."
-	exit 1
+if [[ -f "$DMG_PATH" ]]; then
+	if [[ $OVERWRITE -ne 1 ]]; then
+		echo "Output file already exists. Delete file or use the --overwrite option."
+		exit 1
+	fi
+
+	echo "Deleting existing output file..."
+	rm -f "$DMG_PATH"
 fi
 
 if [[ "${FILESYSTEM}" != "HFS+" ]] && [[ "${FILESYSTEM}" != "APFS" ]]; then
@@ -613,11 +618,6 @@ rm -rf "${MOUNT_DIR}/.fseventsd" || true
 
 echo "Unmounting disk image..."
 hdiutil_retry detach "${DEV_NAME}"
-
-# Remove target if requested
-if [[ $OVERWRITE -eq 1 ]] && [[ -f "${DMG_DIR}/${DMG_NAME}" ]]; then
-	rm -f "${DMG_DIR}/${DMG_NAME}"
-fi
 
 # Return intermediate image if requested
 if [[ $SKIP_FINALIZE -eq 1 ]]; then

--- a/create-dmg
+++ b/create-dmg
@@ -159,9 +159,9 @@ Options:
   --applescript-sleep-duration
       specify the sleep duration before executing AppleScript to workaround occasional "Can’t get disk" (-1728) issues (default is 5)
   --skip-finalize
-      skip creating the file read-only image, and leave a writeable dmg
+      skip creating the final read-only dmg, and leave a writable one
   --overwrite
-	  overwrite the output file if it already exists
+      overwrite the output file if it already exists
   --version
       show create-dmg version number
   -h, --help
@@ -621,7 +621,7 @@ hdiutil_retry detach "${DEV_NAME}"
 
 # Return intermediate image if requested
 if [[ $SKIP_FINALIZE -eq 1 ]]; then
-	mv "${DMG_TEMP_NAME}" "${DMG_DIR}/${DMG_NAME}"
+	mv "$DMG_TEMP_NAME" "$DMG_PATH"
 	echo "Read-write disk image created"
 	exit 0
 fi

--- a/create-dmg
+++ b/create-dmg
@@ -624,18 +624,18 @@ if [[ $SKIP_FINALIZE -eq 1 ]]; then
 	mv "${DMG_TEMP_NAME}" "${DMG_DIR}/${DMG_NAME}"
 	echo "Read-write disk image created"
 	exit 0
-else
-	# Compress image and optionally encrypt
-	if [[ $ENABLE_ENCRYPTION -eq 0 ]]; then
-		echo "Compressing disk image..."
-		hdiutil convert ${HDIUTIL_VERBOSITY} "${DMG_TEMP_NAME}" -format ${FORMAT} ${IMAGEKEY} -o "${DMG_DIR}/${DMG_NAME}"
-	else
-		echo "Compressing and encrypting disk image..."
-		echo "NOTE: hdiutil will only prompt a single time for a password - ensure entry is correct."
-		hdiutil convert ${HDIUTIL_VERBOSITY} "${DMG_TEMP_NAME}" -format ${FORMAT} ${IMAGEKEY} -encryption AES-${AESBITS} -stdinpass -o "${DMG_DIR}/${DMG_NAME}"
-	fi
-	rm -f "${DMG_TEMP_NAME}"
 fi
+
+# Compress image and optionally encrypt
+if [[ $ENABLE_ENCRYPTION -eq 0 ]]; then
+	echo "Compressing disk image..."
+	hdiutil convert ${HDIUTIL_VERBOSITY} "${DMG_TEMP_NAME}" -format ${FORMAT} ${IMAGEKEY} -o "${DMG_DIR}/${DMG_NAME}"
+else
+	echo "Compressing and encrypting disk image..."
+	echo "NOTE: hdiutil will only prompt a single time for a password - ensure entry is correct."
+	hdiutil convert ${HDIUTIL_VERBOSITY} "${DMG_TEMP_NAME}" -format ${FORMAT} ${IMAGEKEY} -encryption AES-${AESBITS} -stdinpass -o "${DMG_DIR}/${DMG_NAME}"
+fi
+rm -f "${DMG_TEMP_NAME}"
 
 # Adding EULA resources
 if [[ -n "${EULA_RSRC}" && "${EULA_RSRC}" != "-null-" ]]; then

--- a/create-dmg
+++ b/create-dmg
@@ -405,7 +405,7 @@ if [[ -f "$DMG_PATH" ]]; then
 	fi
 
 	echo "Deleting existing output file..."
-	rm -f "$DMG_PATH"
+	rm "$DMG_PATH"
 fi
 
 if [[ -f "$SRC_FOLDER/.DS_Store" ]]; then

--- a/create-dmg
+++ b/create-dmg
@@ -404,7 +404,7 @@ if [[ -f "$DMG_PATH" ]]; then
 		exit 1
 	fi
 
-	echo "Deleting existing output file..."
+	echo "Deleting existing output file"
 	rm "$DMG_PATH"
 fi
 

--- a/create-dmg
+++ b/create-dmg
@@ -159,7 +159,7 @@ Options:
   --applescript-sleep-duration
       specify the sleep duration before executing AppleScript to workaround occasional "Can’t get disk" (-1728) issues (default is 5)
   --skip-finalize
-      skip creating the final read-only dmg, and leave a writable one
+      skip creating the final read-only disk image, and leave a writable one
   --overwrite
       overwrite the output file if it already exists
   --version
@@ -622,7 +622,7 @@ hdiutil_retry detach "${DEV_NAME}"
 # Return intermediate image if requested
 if [[ $SKIP_FINALIZE -eq 1 ]]; then
 	mv "$DMG_TEMP_NAME" "$DMG_PATH"
-	echo "Read-write disk image created"
+	echo "Writable disk image created, exit"
 	exit 0
 fi
 

--- a/create-dmg
+++ b/create-dmg
@@ -345,16 +345,6 @@ if [[ "${DMG_PATH: -4}" != ".dmg" ]]; then
 	exit 1
 fi
 
-if [[ -f "$DMG_PATH" ]]; then
-	if [[ $OVERWRITE -ne 1 ]]; then
-		echo "Output file already exists. Delete file or use the --overwrite option."
-		exit 1
-	fi
-
-	echo "Deleting existing output file..."
-	rm -f "$DMG_PATH"
-fi
-
 if [[ "${FILESYSTEM}" != "HFS+" ]] && [[ "${FILESYSTEM}" != "APFS" ]]; then
 	echo "Unknown disk image filesystem: ${FILESYSTEM}. Run 'create-dmg --help' for help."
 	exit 1
@@ -406,6 +396,16 @@ fi
 if [[ ! -d "$CDMG_SUPPORT_DIR" ]]; then
 	echo >&2 "Cannot find support/ directory: expected at: $CDMG_SUPPORT_DIR"
 	exit 1
+fi
+
+if [[ -f "$DMG_PATH" ]]; then
+	if [[ $OVERWRITE -ne 1 ]]; then
+		echo "Output file already exists. Delete file or use the --overwrite option."
+		exit 1
+	fi
+
+	echo "Deleting existing output file..."
+	rm -f "$DMG_PATH"
 fi
 
 if [[ -f "$SRC_FOLDER/.DS_Store" ]]; then


### PR DESCRIPTION
This PR adds a check to see if the target file already exists, as it otherwise errors out when creating the final output.

To fix this there is now a `--overwrite` option that enables overwriting the output file.

To support cases where further customization of the image is required, there is also a `--skip-finalize` option that returns the intermediate write-enabled dmg file.