### PR TITLE
Make the error 1728 workaround sleep duration configurable

### DIFF
--- a/create-dmg
+++ b/create-dmg
@@ -491,7 +491,7 @@ else
 			> "$APPLESCRIPT_FILE"
 
 		# pause to workaround occasional "Can’t get disk" (-1728) issues
-		ERROR_1728_WORKAROUND_SLEEP_INTERVAL=2
+		ERROR_1728_WORKAROUND_SLEEP_INTERVAL="${ERROR_1728_WORKAROUND_SLEEP_INTERVAL:-5}"
 		echo "Will sleep for $ERROR_1728_WORKAROUND_SLEEP_INTERVAL seconds to workaround occasions \"Can't get disk (-1728)\" issues..."
 		sleep $ERROR_1728_WORKAROUND_SLEEP_INTERVAL
 


### PR DESCRIPTION
Hi,

This PR makes the sleep duration used for the error 1728 workaround configurable.

It also increases the default value from 2 to 5 seconds, which worked better in our project.