### PR TITLE
Added --subfolder and --subfolder-name commands

### DIFF
--- a/create-dmg
+++ b/create-dmg
@@ -124,6 +124,10 @@ Options:
       notarize the disk image (waits and staples) with the keychain stored credentials
   --sandbox-safe
       execute hdiutil with sandbox compatibility and do not bless (not supported for APFS disk images)
+  --subfolder
+      put all content of source folder into sub-folder
+  --subfolder-name
+      put all content of source folder into sub-folder with a given name
   --skip-jenkins
       skip Finder-prettifying AppleScript, useful in Sandbox and non-GUI environments
   --version
@@ -251,6 +255,13 @@ while [[ "${1:0:1}" = "-" ]]; do
 		--sandbox-safe)
 			SANDBOX_SAFE=1
 			shift;;
+		--subfolder)
+			DOSUBFOLDER=1
+			shift;;
+		--subfolder-name)
+			DOSUBFOLDER=1
+			SUB_FOLDER_NAME="$2"
+			shift; shift;;
 		--bless)
 			BLESS=1
 			shift;;
@@ -332,6 +343,19 @@ fi
 if [[ ! -d "$CDMG_SUPPORT_DIR" ]]; then
 	echo >&2 "Cannot find support/ directory: expected at: $CDMG_SUPPORT_DIR"
 	exit 1
+fi
+
+if [[ $DOSUBFOLDER == 1 ]]; then
+	SRC_FOLDER_TEMP="${SRC_FOLDER}_tmp/"
+	if [[ "$SUB_FOLDER_NAME" == "" ]]; then
+		SUB_FOLDER_NAME=${SRC_FOLDER##*/}
+	fi
+	SRC_FOLDER_SF="${SRC_FOLDER_TEMP}/$SUB_FOLDER_NAME"
+	echo "Generating subfolder $SRC_FOLDER_SF..."
+	mkdir -p "$SRC_FOLDER_SF"
+	cp -a "$SRC_FOLDER/"* "$SRC_FOLDER_SF"
+	SRC_FOLDER="$SRC_FOLDER_TEMP"
+	find "$SRC_FOLDER" -type f -name ".DS_Store" -delete
 fi
 
 if [[ -f "$SRC_FOLDER/.DS_Store" ]]; then
@@ -627,6 +651,11 @@ if [[ -n "${NOTARIZE}" && "${NOTARIZE}" != "-null-" ]]; then
 		echo "The notarization failed with error $?"
 		exit 1
 	fi
+fi
+
+if [[ $DOSUBFOLDER == 1 ]]; then
+	echo "Removing temporary data..."
+	rm -Rf "${SRC_FOLDER_TEMP}"
 fi
 
 # All done!


### PR DESCRIPTION
These commands can put the whole content of source directory into the sub-directory that will appear on DMG itself. I made these commands a while ago for my own needs, but when I upgraded my copy of script to synchronize with yours, and now I decided to send this argument to mainstream.