### PR TITLE
Fix Perl substitution expressions for file paths containing slashes

### DIFF
--- a/create-dmg
+++ b/create-dmg
@@ -484,10 +484,10 @@ else
 					-e "s/WINH/$WINH/g" -e "s/BACKGROUND_CLAUSE/$BACKGROUND_CLAUSE/g" \
 					-e "s/REPOSITION_HIDDEN_FILES_CLAUSE/$REPOSITION_HIDDEN_FILES_CLAUSE/g" \
 					-e "s/ICON_SIZE/$ICON_SIZE/g" -e "s/TEXT_SIZE/$TEXT_SIZE/g" \
-			| perl -pe "s/POSITION_CLAUSE/$POSITION_CLAUSE/g" \
+			| perl -pe "s:POSITION_CLAUSE:$POSITION_CLAUSE:g" \
 			| perl -pe "s/QL_CLAUSE/$QL_CLAUSE/g" \
 			| perl -pe "s/APPLICATION_CLAUSE/$APPLICATION_CLAUSE/g" \
-			| perl -pe "s/HIDING_CLAUSE/$HIDING_CLAUSE/" \
+			| perl -pe "s:HIDING_CLAUSE:$HIDING_CLAUSE:" \
 			> "$APPLESCRIPT_FILE"
 
 		# pause to workaround occasional "Can’t get disk" (-1728) issues


### PR DESCRIPTION
Hey!!

Fix #160.

## PoC

Script:

```bash
#!/usr/bin/env bash


set +e  # do not fail
set -x  # what did you do?

sub () {
  <<<'foo' perl -pe "s/foo/$1/g"
  <<<'foo' perl -pe "s:foo:$1:g"
}

sub 'bar'
sub 'bar/baz'

```

Output:

```
+ sub bar
+ perl -pe s/foo/bar/g
bar
+ perl -pe s:foo:bar:g
bar
+ sub bar/baz
+ perl -pe s/foo/bar/baz/g
Unknown regexp modifier "/b" at -e line 1, at end of line
Unknown regexp modifier "/z" at -e line 1, at end of line
Execution of -e aborted due to compilation errors.
+ perl -pe s:foo:bar/baz:g
bar/baz

```

.