### PR TITLE
Add --app-drop-link-name option to customize Applications link name

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ All contents of source\_folder will be copied into the disk image.
 - **--icon \<file_name\> \<x\> \<y\>:** set position of the file's icon
 - **--hide-extension \<file_name\>:** hide the extension of file
 - **--app-drop-link \<x\> \<y\>:** make a drop link to Applications, at location x, y
+- **--app-drop-link-name \<name\>:** set the name of the Applications drop link (default is "Applications")
 - **--ql-drop-link \<x\> \<y\>:** make a drop link to /Library/QuickLook, at location x, y
 - **--eula \<eula_file\>:** attach a license file to the dmg
 - **--rez \<rez_path\>:** specify custom path to Rez tool used to include license file

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ All contents of source\_folder will be copied into the disk image.
 - **--icon \<file_name\> \<x\> \<y\>:** set position of the file's icon
 - **--hide-extension \<file_name\>:** hide the extension of file
 - **--app-drop-link \<x\> \<y\>:** make a drop link to Applications, at location x, y
-- **--app-drop-link-name \<name\>:** set the name of the Applications drop link (default is "Applications")
+- **--app-drop-link-name \<name\>:** set the non-empty name of the Applications drop link (default is "Applications")
 - **--ql-drop-link \<x\> \<y\>:** make a drop link to /Library/QuickLook, at location x, y
 - **--eula \<eula_file\>:** attach a license file to the dmg
 - **--rez \<rez_path\>:** specify custom path to Rez tool used to include license file

--- a/create-dmg
+++ b/create-dmg
@@ -343,8 +343,6 @@ if [[ "${FILESYSTEM}" == "APFS" ]] && [[ ${SANDBOX_SAFE} -eq 1 ]]; then
 	exit 1
 fi
 
-# Set APPLICATION_CLAUSE when position is specified
-
 if [[ $ADD_APPLICATION_LINK -eq 1 ]]; then
 	APPLICATION_CLAUSE="set position of item \"$APPLICATION_LINK_NAME\" to {$APPLICATION_LINK_POS_X, $APPLICATION_LINK_POS_Y}
 	"

--- a/create-dmg
+++ b/create-dmg
@@ -34,6 +34,7 @@ SKIP_JENKINS=0
 MAXIMUM_UNMOUNTING_ATTEMPTS=3
 SIGNATURE=""
 NOTARIZE=""
+APPLICATION_LINK_NAME="Applications"
 
 function pure_version() {
 	echo "$CDMG_VERSION"
@@ -94,6 +95,8 @@ Options:
       hide the extension of file
   --app-drop-link <x> <y>
       make a drop link to Applications, at location x,y
+  --app-drop-link-name <name>
+      set the name of the Applications drop link (default is "Applications")
   --ql-drop-link <x> <y>
       make a drop link to user QuickLook install dir, at location x,y
   --eula <eula_file>
@@ -202,10 +205,12 @@ while [[ "${1:0:1}" = "-" ]]; do
 			"
 			shift; shift; shift;;
 		--app-drop-link)
-			APPLICATION_LINK=$2
-			APPLICATION_CLAUSE="set position of item \"Applications\" to {$2, $3}
-			"
+			APPLICATION_LINK_X=$2
+			APPLICATION_LINK_Y=$3
 			shift; shift; shift;;
+		--app-drop-link-name)
+			APPLICATION_LINK_NAME="$2"
+			shift; shift;;
 		--eula)
 			EULA_RSRC=$2
 			shift; shift;;
@@ -302,6 +307,13 @@ fi
 if [[ "${FILESYSTEM}" == "APFS" ]] && [[ ${SANDBOX_SAFE} -eq 1 ]]; then
 	echo "Creating an APFS disk image that is sandbox safe is not supported."
 	exit 1
+fi
+
+# Set APPLICATION_CLAUSE when position is specified
+
+if [[ -n "$APPLICATION_LINK_X" ]]; then
+	APPLICATION_CLAUSE="set position of item \"$APPLICATION_LINK_NAME\" to {$APPLICATION_LINK_X, $APPLICATION_LINK_Y}
+	"
 fi
 
 # Main script logic
@@ -445,10 +457,10 @@ if [[ -n "$BACKGROUND_FILE" ]]; then
 	cp "$BACKGROUND_FILE" "$MOUNT_DIR/.background/$BACKGROUND_FILE_NAME"
 fi
 
-if [[ -n "$APPLICATION_LINK" ]]; then
+if [[ -n "$APPLICATION_LINK_X" ]]; then
 	echo "Making link to Applications dir..."
 	echo $MOUNT_DIR
-	ln -s /Applications "$MOUNT_DIR/Applications"
+	ln -s /Applications "$MOUNT_DIR/$APPLICATION_LINK_NAME"
 fi
 
 if [[ -n "$QL_LINK" ]]; then

--- a/create-dmg
+++ b/create-dmg
@@ -35,6 +35,9 @@ MAXIMUM_HDIUTIL_RETRIES=5
 SIGNATURE=""
 NOTARIZE=""
 ERROR_1728_WORKAROUND_SLEEP_DURATION=5
+ADD_APPLICATION_LINK=0
+APPLICATION_LINK_POS_X=0
+APPLICATION_LINK_POS_Y=0
 APPLICATION_LINK_NAME="Applications"
 
 function pure_version() {
@@ -229,8 +232,9 @@ while [[ "${1:0:1}" = "-" ]]; do
 			"
 			shift; shift; shift;;
 		--app-drop-link)
-			APPLICATION_LINK_X=$2
-			APPLICATION_LINK_Y=$3
+			ADD_APPLICATION_LINK=1
+			APPLICATION_LINK_POS_X=$2
+			APPLICATION_LINK_POS_Y=$3
 			shift; shift; shift;;
 		--app-drop-link-name)
 			APPLICATION_LINK_NAME="$2"
@@ -341,8 +345,8 @@ fi
 
 # Set APPLICATION_CLAUSE when position is specified
 
-if [[ -n "$APPLICATION_LINK_X" ]]; then
-	APPLICATION_CLAUSE="set position of item \"$APPLICATION_LINK_NAME\" to {$APPLICATION_LINK_X, $APPLICATION_LINK_Y}
+if [[ $ADD_APPLICATION_LINK -eq 1 ]]; then
+	APPLICATION_CLAUSE="set position of item \"$APPLICATION_LINK_NAME\" to {$APPLICATION_LINK_POS_X, $APPLICATION_LINK_POS_Y}
 	"
 fi
 
@@ -487,7 +491,7 @@ if [[ -n "$BACKGROUND_FILE" ]]; then
 	cp "$BACKGROUND_FILE" "$MOUNT_DIR/.background/$BACKGROUND_FILE_NAME"
 fi
 
-if [[ -n "$APPLICATION_LINK_X" ]]; then
+if [[ $ADD_APPLICATION_LINK -eq 1 ]]; then
 	echo "Making link to Applications dir..."
 	echo $MOUNT_DIR
 	ln -s /Applications "$MOUNT_DIR/$APPLICATION_LINK_NAME"


### PR DESCRIPTION
Hii!
It's not uncommon for Installer DMGs to set the Applications link name to a single space character (`" "`) to hide the name, because alias names don't automatically change based on the system language.

This patch adds a new `--app-drop-link-name` option that allows users to customize the name of the Applications drop link in DMG files.

**Example usage:**
```bash
# Hide the Applications link text by using a space
create-dmg --app-drop-link-name " " --app-drop-link 400 100 output.dmg source/

# Use a custom name
create-dmg --app-drop-link-name "Install Here" --app-drop-link 400 100 output.dmg source/