### PR TITLE
Add "--hdiutil-retries" and retry all "create" and "detach" operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ All contents of source\_folder will be copied into the disk image.
 - **--disk-image-size \<x\>:** set the disk image size manually to x MB
 - **--hdiutil-verbose:** execute hdiutil in verbose mode
 - **--hdiutil-quiet:** execute hdiutil in quiet mode
+- **--hdiutil-retries \<x\>:** specify the number of retries for the "Resource busy" error from "hdiutil create" and "hdiutil detach" (default is 5)
 - **--bless:** bless the mount folder (deprecated, needs macOS 12.2.1 or older, [#127](https://github.com/create-dmg/create-dmg/pull/127))
 - **--codesign \<signature\>:** codesign the disk image with the specified signature
 - **--notarize \<credentials>:** notarize the disk image (waits and staples) with the keychain stored credentials

--- a/create-dmg
+++ b/create-dmg
@@ -31,7 +31,7 @@ HDIUTIL_VERBOSITY=""
 SANDBOX_SAFE=0
 BLESS=0
 SKIP_JENKINS=0
-MAXIMUM_UNMOUNTING_ATTEMPTS=3
+MAXIMUM_HDIUTIL_RETRIES=5
 SIGNATURE=""
 NOTARIZE=""
 
@@ -39,24 +39,43 @@ function pure_version() {
 	echo "$CDMG_VERSION"
 }
 
-function hdiutil_detach_retry() {
-	# Unmount
-	unmounting_attempts=0
-	until
-		echo "Unmounting disk image..."
-		(( unmounting_attempts++ ))
-		hdiutil detach "$1"
-		exit_code=$?
-		(( exit_code ==  0 )) && break            # nothing goes wrong
-		(( exit_code != 16 )) && exit $exit_code  # exit with the original exit code
-		# The above statement returns 1 if test failed (exit_code == 16).
-		#   It can make the code in the {do... done} block to be executed
-	do
-		(( unmounting_attempts == MAXIMUM_UNMOUNTING_ATTEMPTS )) && exit 16  # patience exhausted, exit with code EBUSY
-		echo "Wait a moment..."
-		sleep $(( 1 * (2 ** unmounting_attempts) ))
+function hdiutil_retry() {
+	# "hdiutil detach" exits with code 16 (EBUSY) when "Resource busy", while "hdiutil create" uses code 1
+	#   for the same error, so we have to collect "Resource busy" from their normal or verbose logs
+	local hdiutil_args=() i=0
+	for arg in "$@"; do
+		if [[ "$arg" != '-quiet' ]]; then
+			hdiutil_args[$i]="$arg"
+			(( ++i ))  # do not use "i++", otherwise breaks in Bash 4.1+
+		fi
 	done
-	unset unmounting_attempts
+
+	local log_file="$(mktemp)" hdiutil_retries=0 exit_code=0
+	until
+		(( ++hdiutil_retries ))
+
+		# no pipe, otherwise "diskimages-helper -processKernelRequest: will sleep received" forever
+		hdiutil "${hdiutil_args[@]}" >"$log_file" 2>&1
+		exit_code=$?
+
+		# show the log conditional
+		[[ "$HDIUTIL_VERBOSITY" != '-quiet' ]] && cat "$log_file"
+
+		# nothing goes wrong
+		(( exit_code == 0 )) && break
+
+		# Will return 1 if the math test fails (found "Resource busy"), then it will make
+		#   the {do... done} code block be executed, otherwise it will exit with the original exit code
+		(( "$(grep -w 'Resource busy' "$log_file" | wc -l)" == 0 )) && exit $exit_code
+	do
+		# patience exhausted, exit with the original exit code
+		(( hdiutil_retries >= MAXIMUM_HDIUTIL_RETRIES )) && exit $exit_code
+
+		echo "Wait a moment for \"Resource busy\"..."
+		sleep $(( 1 * (2 ** hdiutil_retries) ))
+	done
+
+	rm "$log_file"
 }
 
 function version() {
@@ -116,6 +135,8 @@ Options:
       execute hdiutil in verbose mode
   --hdiutil-quiet
       execute hdiutil in quiet mode
+  --hdiutil-retries <x>
+      specify the number of retries for the "Resource busy" error from "hdiutil create" and "hdiutil detach" (default is 5)
   --bless
       bless the mount folder (deprecated, needs macOS 12.2.1 or older)
   --codesign <signature>
@@ -242,6 +263,9 @@ while [[ "${1:0:1}" = "-" ]]; do
 		--hdiutil-quiet)
 			HDIUTIL_VERBOSITY='-quiet'
 			shift;;
+		--hdiutil-retries)
+			MAXIMUM_HDIUTIL_RETRIES="$2"
+			shift; shift;;
 		--codesign)
 			SIGNATURE="$2"
 			shift; shift;;
@@ -375,7 +399,7 @@ if [[ $SANDBOX_SAFE -eq 0 ]]; then
 	else
 		FILESYSTEM_ARGUMENTS="-c c=64,a=16,e=16"
 	fi
-	hdiutil create ${HDIUTIL_VERBOSITY} -srcfolder "$SRC_FOLDER" -volname "${VOLUME_NAME}" \
+	hdiutil_retry create ${HDIUTIL_VERBOSITY} -srcfolder "$SRC_FOLDER" -volname "${VOLUME_NAME}" \
 		-fs "${FILESYSTEM}" -fsargs "${FILESYSTEM_ARGUMENTS}" -format UDRW ${CUSTOM_SIZE} "${DMG_TEMP_NAME}"
 else
 	hdiutil makehybrid ${HDIUTIL_VERBOSITY} -default-volume-name "${VOLUME_NAME}" -hfs -o "${DMG_TEMP_NAME}" "$SRC_FOLDER"
@@ -501,7 +525,7 @@ else
 			true
 		else
 			echo >&2 "Failed running AppleScript"
-			hdiutil_detach_retry "${DEV_NAME}"
+			hdiutil_retry detach "${DEV_NAME}"
 			exit 64
 		fi
 		echo "Done running the AppleScript..."
@@ -543,7 +567,8 @@ fi
 echo "Deleting .fseventsd"
 rm -rf "${MOUNT_DIR}/.fseventsd" || true
 
-hdiutil_detach_retry "${DEV_NAME}"
+echo "Unmounting disk image..."
+hdiutil_retry detach "${DEV_NAME}"
 
 # Compress image and optionally encrypt
 if [[ $ENABLE_ENCRYPTION -eq 0 ]]; then


### PR DESCRIPTION
## Description

The "Resource busy" error has been an old story since long, long ago:

- (Posted on Jul 24, 2009) Random failure with "hdiutil create" - Apple Community - https://discussions.apple.com/thread/2092648
- [Recipe fails due to 'hdiutil: couldn't unmount "diskX" - Resource busy' · Issue #391 · autopkg/autopkg](https://github.com/autopkg/autopkg/issues/391)
- [hdiutil unmount issue blocks dmg creation for MacOS builds · Issue #4606 · electron-userland/electron-builder](https://github.com/electron-userland/electron-builder/issues/4606)

Since analyzing against closed-source programs is too difficult for me, I use the "trial and error" method instead. It's not only can AAPL do it, but we can too.

This PR will help those people:

- hdiutil create
  - #190
  - #143
  - #114
  - #99
  - [\[macOS\] hdiutil failures when creating DMGs · Issue #7522 · actions/runner-images](https://github.com/actions/runner-images/issues/7522)
- hdiutil detach
  - https://github.com/create-dmg/create-dmg/issues/164#issuecomment-1981544049
  - https://github.com/create-dmg/create-dmg/issues/190#issuecomment-3354259697

Please read the code for details about the new logic.

## How to Test

### Mock Test in Bash

Testee and mock are in the "hdiutil_retry.sh" file:

<details>
<summary>shell script: Testee and mock</summary>

```shell
#!/bin/bash
set -e

# testee
MAXIMUM_HDIUTIL_RETRIES=5
function hdiutil_retry() {
	# please copy the code from the script
}

# mock
function hdiutil() {
	local operation="$1" verbosity=''

	if [[ "$operation" != 'create' ]] && [[ "$operation" != 'detach' ]]; then
		echo 'unknown operation'; exit 22
	fi
	shift;

	while [[ "${1:0:1}" = "-" ]]; do
		case $1 in
			-verbose) verbosity="verbose"; shift; break;;
			-quiet) verbosity="quiet"; shift; break;;
		esac
	done

	if [[ -z "$2" ]]; then
		echo "Not enough arguments."; exit 22
	fi
	if [[ -n "$3" ]]; then
		echo "Too many arguments."; exit 22
	fi

	local ret=0 log='done'
	if [[ "$operation" == 'detach' ]] && (( $RANDOM % 5 == 0 )); then
		# hdiutil detach (others)
		ret=8; log='ate'
	elif [[ "$operation" == 'create' ]] && (( $RANDOM % 5 == 0 )); then
		# hdiutil create (others)
		ret=42; log='the answer'
	elif [[ "$operation" == 'detach' ]] && (( $RANDOM % 2 == 0 )); then
		# hdiutil detach (EBUSY)
		ret=16; log="couldn't eject \"disk1\" - Resource busy"
	elif [[ "$operation" == 'create' ]] && (( $RANDOM % 3 == 0 )); then
		# hdiutil create
		ret=1; log='create failed - Resource busy'
	fi

	[[ "$verbosity" == 'verbose' ]] && echo "diskimages-helper: ..."
	[[ "$verbosity" != 'quiet' ]] && echo "hdiutil: $log"
	return $ret
}

# main
hdiutil_retry "$@"

```

</details>

Tester:

<details>
<summary>shell script: tester</summary>

```shell
#!/bin/bash
set +e

# tester
for op in 'create' 'detach' 'AAPL'; do
	echo "====== START ($op) ======"

	for HDIUTIL_VERBOSITY in '-quiet' '' '-verbose'; do
		echo "--- v ($HDIUTIL_VERBOSITY) ---"

		args=($op)
		[[ -n "$HDIUTIL_VERBOSITY" ]] && args+=("$HDIUTIL_VERBOSITY")
		args+=("$(mktemp -u).dmg" '/Applications/Firefox.app')

		export HDIUTIL_VERBOSITY

		bash ./hdiutil_retry.sh "${args[@]}"

		echo "--- code ($?) ---"
	done

	echo "====== END ($op) ======"
done

```

</details>

You may get the result as follows:

<details>
<summary>plaintext: example output</summary>

```
====== START (create) ======
--- v (-quiet) ---
Wait a moment for "Resource busy"...
--- code (0) ---
--- v () ---
hdiutil: done
--- code (0) ---
--- v (-verbose) ---
diskimages-helper: ...
hdiutil: create failed - Resource busy
Wait a moment for "Resource busy"...
diskimages-helper: ...
hdiutil: done
--- code (0) ---
====== END (create) ======
====== START (detach) ======
--- v (-quiet) ---
--- code (0) ---
--- v () ---
hdiutil: couldn't eject "disk1" - Resource busy
Wait a moment for "Resource busy"...
hdiutil: couldn't eject "disk1" - Resource busy
Wait a moment for "Resource busy"...
hdiutil: done
--- code (0) ---
--- v (-verbose) ---
diskimages-helper: ...
hdiutil: done
--- code (0) ---
====== END (detach) ======
====== START (AAPL) ======
--- v (-quiet) ---
--- code (22) ---
--- v () ---
--- code (22) ---
--- v (-verbose) ---
--- code (22) ---
====== END (AAPL) ======
```

</details>

### Real Test with manipulating Spotlight on GitHub Actions Runners

All tests will take about 3 hours in total. The ARM-based macOS is faster than the Intel-based one.

Workflow file:

<details>
<summary>yaml file: example CI workflow</summary>

```YAML
name: CI
on:
  push:
  pull_request:
  workflow_dispatch:
jobs:
  build:
    runs-on: ${{ matrix.os_ver }}
    strategy:
      fail-fast: true
      matrix:
        os_ver: [macos-14, macos-15, macos-15-intel, macos-26]
        spotlight: [on, off]
    steps:
      - uses: actions/checkout@v5.0.0

      - name: Turning Spotlight ${{ matrix.spotlight }}
        run: |
          set -ex

          mdutil -s -a

          # You may encounter:
          #   /:
          #   Error: unable to perform operation.  (-1)
          #     Error: unknown indexing state.
          #   /System/Volumes/Data:
          #   Error: invalid operation.
          #     Error: unknown indexing state.
          #   /System/Volumes/Preboot:
          #   Error: invalid operation.
          #     Error: unknown indexing state.
          sudo mdutil -i '${{ matrix.spotlight }}' -a

          mdutil -s -a

      - name: Package
        run: |
          set -eu

          for i in $(seq 0 42); do
            echo "====== START ($i) ======"

            ps -ef | grep 'mds'
            mdutil -s -a

            for verbosity in '--hdiutil-quiet' '' '--hdiutil-verbose'; do
              echo "--- v ($verbosity) ---"

              dmg_path="$(mktemp -u).dmg" args=()
              [[ -n "$verbosity" ]] && args+=("$verbosity")
              args+=("$dmg_path" '/Applications/Firefox.app')

              bash ./create-dmg "${args[@]}"

              rm "$dmg_path"
            done

            echo "====== END ($i) ======"
          done

```

</details>

2025-11-17 test result:

```console
$ grep -c 'Wait a moment for "Resource busy"' ./*.txt
./0_build (macos-15-intel, on).txt:38
./1_build (macos-14, on).txt:2
./2_build (macos-14, off).txt:5
./3_build (macos-15-intel, off).txt:21
./4_build (macos-26, on).txt:9
./5_build (macos-15, on).txt:4
./6_build (macos-26, off).txt:2
./7_build (macos-15, off).txt:5

```

We can see that the "Resource busy" error and Spotlight seem to be slightly related, but it's not so obvious.
