### PR TITLE
Check if the two positional arguments are at the end

### DIFF
--- a/create-dmg
+++ b/create-dmg
@@ -325,6 +325,12 @@ fi
 
 DMG_PATH="$1"
 SRC_FOLDER="$(cd "$2" > /dev/null; pwd)"
+shift; shift
+
+if [[ -n "$@" ]]; then
+	echo "Unexpected arguments appear after positional arguments. Run 'create-dmg --help' for help."
+	exit 1
+fi
 
 # Argument validation checks
 


### PR DESCRIPTION
Two arguments: DMG_PATH & SRC_FOLDER.

---

Stupid me wrote `create-dmg ... --foo bar` and yelled "wut?!" due to the wrong result. So, I made this.

Before:

```console
$ ./create-dmg 
Not enough arguments. Run 'create-dmg --help' for help.
$ ./create-dmg 'foo.dmg'
Not enough arguments. Run 'create-dmg --help' for help.
$ ./create-dmg 'foo.dmg' ''
Not enough arguments. Run 'create-dmg --help' for help.
$ ./create-dmg 'foo.dmg' '.' --volname 'foo'
Deleting .DS_Store found in source folder
...

```

After:

```console
$ ./create-dmg
Not enough arguments. Run 'create-dmg --help' for help.
$ ./create-dmg 'foo.dmg'
Not enough arguments. Run 'create-dmg --help' for help.
$ ./create-dmg 'foo.dmg' ''
Not enough arguments. Run 'create-dmg --help' for help.
$ ./create-dmg 'foo.dmg' '.' --volname 'foo'
Unexpected arguments appear after positional arguments. Run 'create-dmg --help' for help.
$ ./create-dmg 'foo.dmg' '.' 
Deleting .DS_Store found in source folder
...

```

Tested on Mac OS X 10.7.5.