### PR TITLE
Do not read from or write to non-existing directories

### DIFF
--- a/create-dmg
+++ b/create-dmg
@@ -336,7 +336,7 @@ if [[ -z "$2" ]]; then
 fi
 
 DMG_PATH="$1"
-SRC_FOLDER="$(cd "$2" > /dev/null; pwd)"
+SRC_FOLDER="$(cd "$2" > /dev/null && pwd)"
 shift; shift
 
 if [[ -n "$@" ]]; then
@@ -370,7 +370,7 @@ fi
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 DMG_DIRNAME="$(dirname "$DMG_PATH")"
-DMG_DIR="$(cd "$DMG_DIRNAME" > /dev/null; pwd)"
+DMG_DIR="$(cd "$DMG_DIRNAME" > /dev/null && pwd)"
 DMG_NAME="$(basename "$DMG_PATH")"
 DMG_TEMP_NAME="$DMG_DIR/rw.$$.${DMG_NAME}"
 


### PR DESCRIPTION
Comparison:

```console
$ ./create-dmg './non-existing-dest/foo.dmg' './non-existing-src'
./create-dmg: line 339: cd: ./non-existing-src: No such file or directory
$ ./create-dmg './non-existing-dest/foo.dmg' './'
./create-dmg: line 373: cd: ./non-existing-dest: No such file or directory

$ git checkout HEAD~1 
$ ./create-dmg './non-existing-dest/foo.dmg' './non-existing-src'
./create-dmg: line 339: cd: ./non-existing-src: No such file or directory
./create-dmg: line 373: cd: ./non-existing-dest: No such file or directory
Deleting .DS_Store found in source folder
...
... (then the script uses the current working directory for both input and output)

```

A current correct usage:

https://github.com/create-dmg/create-dmg/blob/3da6aba5082959d292889b01539b8b2e8feb00de/create-dmg#L371

Don't miss this popular QA on SO:

- How do I get the directory where a Bash script is located from within the script itself? - Stack Overflow | https://stackoverflow.com/q/59895

.