### PR TITLE
Fix AppleScript disk selection issue on OSX 10.6; add OS version check

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,11 +117,13 @@ Nothing except a standard installation of macOS/OS X is required.
 
 We think this works in OS X 10.6 Snow Leopard and later.
 
-We'd like to keep it working in as many versions as possible, but unfortunately, we just don't have test boxes running old versions of OS X adequate to make this happen. Development and testing mostly happens in the last 3-5 years' worth of macOS releases; as of 2020, this means macOS 10.12 and later.
+We'd like to keep it working in as many versions as possible, but unfortunately, we just don't have test boxes running old versions of OS X adequate to make this happen. Development and testing mostly happens in the last 3-5 years' worth of macOS releases; as of 2026, this means macOS 13 and later.
 
 But if you find a bug in an older version, go ahead and report it! We'll try to work with you to get it fixed.
 
-If you're running OS X 10.5 or earlier, you're SOL. That's just too hard to deal with in 2023. ;)
+If you're running OS X 10.5 or earlier, you're SOL. That's just too hard to deal with in 2026. ;)
+
+On OS X 10.6 Snow Leopard, due to Finder's unknown bug, concurrent runs of this script may race on the same volume name, so it's not recommended to do so.
 
 Alternatives
 ------------

--- a/create-dmg
+++ b/create-dmg
@@ -344,6 +344,13 @@ if [[ -n "$@" ]]; then
 	exit 1
 fi
 
+# Environment checks
+
+if [[ "$OS_MAJOR_VERSION" -eq 10 ]] && [[ "$OS_MINOR_VERSION" -lt 6 ]]; then
+	echo "Mac OS X 10.6 Snow Leopard is the oldest supported version of the OS."
+	exit 1
+fi
+
 # Argument validation checks
 
 if [[ "${DMG_PATH: -4}" != ".dmg" ]]; then
@@ -551,8 +558,6 @@ if [[ -n "$ADD_FILE_SOURCES" ]]; then
 	done
 fi
 
-VOLUME_NAME=$(basename $MOUNT_DIR)
-
 # Run AppleScript to do all the Finder cosmetic stuff
 APPLESCRIPT_FILE=$(mktemp -t createdmg.tmp.XXXXXXXXXX)
 if [[ $SANDBOX_SAFE -eq 1 ]]; then
@@ -574,8 +579,16 @@ else
 		echo "Will sleep for $ERROR_1728_WORKAROUND_SLEEP_DURATION seconds to workaround occasions \"Can't get disk (-1728)\" issues..."
 		sleep $ERROR_1728_WORKAROUND_SLEEP_DURATION
 
-		echo "Running AppleScript to make Finder stuff pretty: /usr/bin/osascript \"${APPLESCRIPT_FILE}\" \"${VOLUME_NAME}\""
-		if /usr/bin/osascript "${APPLESCRIPT_FILE}" "${VOLUME_NAME}"; then
+		if [[ "$OS_MAJOR_VERSION" -eq 10 ]] && [[ "$OS_MINOR_VERSION" -eq 6 ]]; then
+			# For the buggy Finder on Mac OS X 10.6 Snow Leopard, otherwise "Can't get disk (-1728)" for ever.
+			# Conflict is not avoidable if there are multiple mounted volumes that
+			#   have the same volume name, so concurrently processing multiple disks may fail
+			DISK_NAME="${VOLUME_NAME}"
+		else
+			DISK_NAME="$(basename $MOUNT_DIR)"
+		fi
+		echo "Running AppleScript to make Finder stuff pretty: /usr/bin/osascript \"${APPLESCRIPT_FILE}\" \"${DISK_NAME}\" \"${MOUNT_DIR}\""
+		if /usr/bin/osascript "${APPLESCRIPT_FILE}" "${DISK_NAME}" "${MOUNT_DIR}"; then
 			# Okay, we're cool
 			true
 		else

--- a/support/template.applescript
+++ b/support/template.applescript
@@ -1,6 +1,6 @@
-on run (volumeName)
+on run (diskName, mountDir)
 	tell application "Finder"
-		tell disk (volumeName as string)
+		tell disk (diskName as string)
 			open
 
 			set theXOrigin to WINX
@@ -10,7 +10,7 @@ on run (volumeName)
 
 			set theBottomRightX to (theXOrigin + theWidth)
 			set theBottomRightY to (theYOrigin + theHeight)
-			set dsStore to "\"" & "/Volumes/" & volumeName & "/" & ".DS_STORE\""
+			set dsStore to quoted form of (mountDir & "/.DS_STORE")
 
 			tell container window
 				set current view to icon view
@@ -51,7 +51,7 @@ on run (volumeName)
 
 		delay 1
 
-		tell disk (volumeName as string)
+		tell disk (diskName as string)
 			tell container window
 				set statusbar visible to false
 				set the bounds to {theXOrigin, theYOrigin, theBottomRightX, theBottomRightY}


### PR DESCRIPTION
Hi.

## Where is Snow Leopard?

First, please check git-diff to read comments about this bunch of changes.

Then, here is my test result and screenshots.

| OS Version | Result | Screenshot |
|:-:|:-:| - |
| Mac OS X 10.6.8 | Failed before the fix | <img height="100" alt="osx-10-6-8-create-dmg-comparison" src="https://github.com/user-attachments/assets/19c74f10-b6db-4889-a56d-934294c54541" /> |
| Mac OS X 10.7.5 | Both OK | <img height="100" alt="osx-10-7-5-create-dmg-comparison" src="https://github.com/user-attachments/assets/0cf0c6d6-2d4a-46fb-9273-b51163f96c46" /> |
| macOS 15.7.2 | Both OK | <img height="100" alt="macos-15-7-2-create-dmg-comparison" src="https://github.com/user-attachments/assets/3e2ab457-fbd1-41d9-8467-3baadaca58e7" /> |

The crucial error message in the screenshot on OS X 10.6:

```
...: execution error: Finder got an error: Can’t get disk "...". (-1728)

```

That is, the Finder didn't Find our volumes by the name of the directory under `/Volumes`, or say, the mount point. I can't Find any official reference about this weird behavior, either. Fortunately, we've had correct result since OS X 10.7.

## Concurrency Test

A simple script:

```shell
#!/bin/bash

set -eux

create_dmg_dir="$PWD"

vol_name="$1"
dmg_name="${vol_name}.dmg"
num="$2"

i=0
while [ $i -ne "$num" ]; do
        i=$(($i+1))
        echo "i = $i starting"
        temp_dir="$(mktemp -d -t createdmg.tmp.XXXXXXXXXX)"
        (
                cd "$temp_dir"
                "$create_dmg_dir/create-dmg" ./"$dmg_name" "$create_dmg_dir"

                echo "i = $i completed with code $?"
        ) &
done

```

Failed run's output on Mac OSX 10.6.8:

```
$ bash ./concurrent.sh foo 2
...
+ .../create-dmg/create-dmg ./foo.dmg .../create-dmg
+ .../create-dmg/create-dmg ./foo.dmg .../create-dmg
$ 
Deleting .DS_Store found in source folder
Deleting .DS_Store found in source folder
...
Running AppleScript to make Finder stuff pretty: /usr/bin/osascript "/tmp/createdmg.tmp.XXXXXXXXXX.51VWSrWI" "foo" "/Volumes/dmg.cF3MdX"
Running AppleScript to make Finder stuff pretty: /usr/bin/osascript "/tmp/createdmg.tmp.XXXXXXXXXX.a7VwBW5n" "foo" "/Volumes/dmg.MSLCkC"
Done running the AppleScript...
...
i = 2 completed with code 0

$ 
$ ps -ef | grep osascript
  ... /usr/bin/osascript /tmp/createdmg.tmp.XXXXXXXXXX.51VWSrWI foo /Volumes/dmg.cF3MdX
$ killall osascript
  ... Terminated              /usr/bin/osascript "${APPLESCRIPT_FILE}" "${DISK_NAME}" "${MOUNT_DIR}"
Failed running AppleScript
$ 
"disk3" unmounted.
"disk3" ejected.

```

So, the support for OSX 10.6 won't be fully functional, but it will work again.
